### PR TITLE
月のサイズのValidationを10以上にする

### DIFF
--- a/web/backend/app/models/converter/text_to_moon.rb
+++ b/web/backend/app/models/converter/text_to_moon.rb
@@ -8,10 +8,10 @@ module Converter
     CONVERT_SIZE = 4
 
     attribute :text, :string
-    attribute :size, :integer, default: 20
+    attribute :size, :integer, default: 10
 
     validates :text, presence: true
-    validates :text, length: { minimum: 1, maximum: 20 }
+    validates :text, length: { minimum: 1, maximum: 10 }
     validates :text, format: { with: /\A[ぁ-んァ-ンa-zA-Z0-9ー０-９Ａ-Ｚａ-ｚ 　]+\z/, message: '変換できるのは全角半角英数字、ひらがなカタカナのみです。' }
     validates :size, numericality: { only_integer: true, greater_than_or_equal_to: 20, less_than_or_equal_to: 100 }
 

--- a/web/backend/app/models/converter/text_to_moon.rb
+++ b/web/backend/app/models/converter/text_to_moon.rb
@@ -11,9 +11,9 @@ module Converter
     attribute :size, :integer, default: 10
 
     validates :text, presence: true
-    validates :text, length: { minimum: 1, maximum: 10 }
+    validates :text, length: { minimum: 1, maximum: 20 }
     validates :text, format: { with: /\A[ぁ-んァ-ンa-zA-Z0-9ー０-９Ａ-Ｚａ-ｚ 　]+\z/, message: '変換できるのは全角半角英数字、ひらがなカタカナのみです。' }
-    validates :size, numericality: { only_integer: true, greater_than_or_equal_to: 20, less_than_or_equal_to: 100 }
+    validates :size, numericality: { only_integer: true, greater_than_or_equal_to: 10, less_than_or_equal_to: 100 }
 
     def initialize(params = {})
       super(params)

--- a/web/backend/spec/models/converter/text_to_moon_spec.rb
+++ b/web/backend/spec/models/converter/text_to_moon_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Converter::TextToMoon, type: :model do
   describe '.call' do
     context 'textに半角全角英数字、ひらがなカタカナ以外の文字が含まれているとき' do
       it '漢字を含んでいるのでエラーが発生することを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: '漢字', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: '漢字', size: 10)
         expect(text_to_moon.valid?).to be false
       end
     end

--- a/web/backend/spec/models/converter/text_to_moon_spec.rb
+++ b/web/backend/spec/models/converter/text_to_moon_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Converter::TextToMoon, type: :model do
 
     context 'textに半角全角英数字、ひらがなカタカナの文字が含まれているとき' do
       it 'ひらがなのみなのでエラーにならないことを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: 'あいうえお', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: 'あいうえお', size: 10)
         expect(text_to_moon.valid?).to be true
       end
 
       it 'カタカナのみなのでエラーにならないことを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: 'アイウエオ', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: 'アイウエオ', size: 10)
         expect(text_to_moon.valid?).to be true
       end
 
       it '半角英数字のみなのでエラーにならないことを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: 'abcde12345', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: 'abcde12345', size: 10)
         expect(text_to_moon.valid?).to be true
       end
 
       it '全角英数字のみなのでエラーにならないことを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: 'ＡＢＣＤＥ１２３４５', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: 'ＡＢＣＤＥ１２３４５', size: 10)
         expect(text_to_moon.valid?).to be true
       end
 
       it 'textとsizeに受け取ったパラメータが設定されていることを確認' do
-        text_to_moon = Converter::TextToMoon.new(text: 'ＡＢＣＤＥ１２３４５', size: 20)
+        text_to_moon = Converter::TextToMoon.new(text: 'ＡＢＣＤＥ１２３４５', size: 10)
         response = text_to_moon.call
         expect(response[:text]).to eq 'ＡＢＣＤＥ１２３４５'
-        expect(response[:size]).to eq 20
+        expect(response[:size]).to eq 10
       end
 
     end

--- a/web/backend/spec/requests/v1/text_to_moons_spec.rb
+++ b/web/backend/spec/requests/v1/text_to_moons_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'V1::TextToMoons', type: :request do
   describe 'GET v1/text_to_moons' do
     let(:headers) { { 'ACCEPT' => 'application/json' } }
-    let(:params) { { text: 'test', size: 10 } }
+    let(:params) { { text: 'test', size: 1 } }
 
     context 'validationに引っかかるリクエストを送る場合' do
       it '400エラーがかえること' do

--- a/web/compose.yml
+++ b/web/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mysql:8.1.0

--- a/web/frontend/.env.development
+++ b/web/frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL='https://api.starry-kids.com/v1'
+VITE_API_BASE_URL='http://localhost:5173'

--- a/web/frontend/.env.development
+++ b/web/frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL='http://localhost:5173'
+VITE_API_BASE_URL='http://localhost:3000/v1'

--- a/web/frontend/src/pages/TopPage.vue
+++ b/web/frontend/src/pages/TopPage.vue
@@ -10,7 +10,7 @@ import { computed } from "vue";
 import { ComputedRef } from "vue";
 import { reactive } from "vue";
 
-const size = ref<number>(20);
+const size = ref<number>(10);
 const text = ref<string>("");
 const isValid = ref<boolean>(false);
 const response = ref<string[]>([]);
@@ -37,10 +37,10 @@ const inputNumberOnly = (inputValue: string): boolean | string => {
   const regex = /^[0-9]+$/;
   return regex.test(inputValue) || "数字を入力してください";
 };
-const inputNumber20to100 = (inputValue: string): boolean | string => {
-  // 20 ~ 100の数字のみの入力を許可する
-  const regex = /^[2-9][0-9]$|^100$/;
-  return regex.test(inputValue) || "20 ~ 100の数字を入力してください";
+const inputNumber10to100 = (inputValue: string): boolean | string => {
+  // 10 ~ 100の数字のみの入力を許可する
+  const regex = /^[1-9][0-9]$|^100$/;
+  return regex.test(inputValue) || "10 ~ 100の数字を入力してください";
 };
 
 const inputText1to20 = (inputValue: string): boolean | string => {
@@ -83,9 +83,9 @@ onErrorCaptured((err: Error) => {
               <v-form @submit.prevent v-model="isValid">
                 <v-text-field
                   v-model="size"
-                  :rules="[inputNumberOnly, inputNumber20to100]"
+                  :rules="[inputNumberOnly, inputNumber10to100]"
                   label="月のサイズ"
-                  placeholder="20 ~ 100"
+                  placeholder="10 ~ 100"
                 ></v-text-field>
 
                 <v-text-field

--- a/web/frontend/src/pages/TopPage.vue
+++ b/web/frontend/src/pages/TopPage.vue
@@ -10,7 +10,7 @@ import { computed } from "vue";
 import { ComputedRef } from "vue";
 import { reactive } from "vue";
 
-const size = ref<number>(10);
+const size = ref<number>(15);
 const text = ref<string>("");
 const isValid = ref<boolean>(false);
 const response = ref<string[]>([]);


### PR DESCRIPTION
## 🥅 このプルリクのゴール / Resolved Issues
- 月のサイズの最小値を20ではなく10にする

## 👏 解決する issue / Resolved Issues
<!-- 解決するissueがある場合はissue番号と内容を書いて下さい -->
- #38 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- modelの月のサイズのValidationを10にする
  - デフォルト値も10にした
  - テストを修正
- VueのValidationも10以上になるようにした
  - デフォルト値を10にした
- `.env.development`に書いている接続先がローカルに向いていないので向くようにした
- `docker-compose.yml`を`compose.yml`にした。
  - docker composeのv2の仕様に沿って見ました。ついでにファイル内の`version: '3'`も消しました。


## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

10でも動くことを確認。けど10だとなんか微妙に表現しきれてないかも？（これは感じ方に個人差ありそうなので10でもいっかという気持ちです）

<img width="1228" alt="Screenshot 2023-10-29 at 23 35 35" src="https://github.com/Tatsumi0000/starry-kids/assets/19218690/c42a6da1-e732-42c5-bdf8-b72c5b51e36c">

<details>
    <summary>出力した月文字</summary>

🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌕🌕🌕🌕🌕
🌕🌕🌕🌘🌑🌑🌓🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌔🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌖🌑🌑🌒🌕🌕🌕
🌕🌕🌕🌒🌕🌕🌗🌔🌕🌕
🌕🌕🌖🌑🌑🌑🌑🌔🌕🌕
🌕🌕🌕🌒🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌗🌒🌕🌘🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌗🌑🌑🌓🌕🌕🌕
🌕🌕🌕🌘🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌖🌑🌒🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌖🌒🌕🌕🌕
🌕🌕🌕🌑🌕🌗🌒🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌕🌕🌕🌕🌕
🌕🌕🌕🌘🌑🌑🌓🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌑🌕🌕🌕🌕🌕
🌕🌕🌕🌕🌘🌔🌕🌕🌕🌕
🌕🌕🌕🌕🌕🌕🌕🌕🌕🌕


</details>


## ❗️ 気になる点 / Concern points
- 今後感じなども対応するときは10だときれいにならさそうだけど10にしておく。
  - 📝 Vue側で漢字は20以上がいいかもよ〜みたいなのを入れてユーザに任せるとかにするといいかも
