### PR TITLE
Google Analyticsを入れる

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "qs": "^6.11.2",
         "vite-plugin-vuetify": "^1.0.2",
         "vue": "^3.3.4",
+        "vue-gtag": "^2.0.1",
         "vue-router": "^4.3.0",
         "vuetify": "^3.5.8"
       },
@@ -5445,6 +5446,14 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-gtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-2.0.1.tgz",
+      "integrity": "sha512-aM4A58FVL0wV2ptYi+xzAjeg+pQVRyUcfBc5UkXAwQrR4t3WBhor50Izp2I+3Oo7+l+vWJ7u78DGcNzReb8S/A==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -18,6 +18,7 @@
     "qs": "^6.11.2",
     "vite-plugin-vuetify": "^1.0.2",
     "vue": "^3.3.4",
+    "vue-gtag": "^2.0.1",
     "vue-router": "^4.3.0",
     "vuetify": "^3.5.8"
   },

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import VueGtag from "vue-gtag";
 import vuetify from "../plugins/vuetify";
 import router from "./configs/router";
 import "@mdi/font/css/materialdesignicons.css";
@@ -7,4 +8,7 @@ import "@mdi/font/css/materialdesignicons.css";
 const app = createApp(App);
 app.use(vuetify);
 app.use(router);
+app.use(VueGtag, {
+    config: { id: "G-9VS0SV5JBW" }
+});
 app.mount("#app");


### PR DESCRIPTION
## 🥅 このプルリクのゴール / Resolved Issues
- Google Analyticsを入れる

## 👏 解決する issue / Resolved Issues
<!-- 解決するissueがある場合はissue番号と内容を書いて下さい -->
- close #177 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- vue-gtagライブラリを入れます
  - VueでGoogle Analyticsを使うために入れました。
  - vue-analyticsはメンテモードに入っているのでこっちを使ってます。
- main.tsで初期化処理をするようにしました。
  - [vue-gtagの公式ドキュメント](https://matteo-gabriele.gitbook.io/vue-gtag/)を参考に実装しています。

> [!NOTE]
> 本当はローカル開発中は計測しないみたいなのをしたかったけど、Railsがローカルで動かず動作検証できなかったので実装を諦めました。
> やるなら、`vite.config.ts`で分岐させてパラメータを入れるといい感じに実装できそうかなと思ってます。

## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

## ❗️ 気になる点 / Concern points
- なし
