### PR TITLE
月文字の画像保存機能を作成

### DIFF
--- a/web/frontend/src/components/DownloadButton.vue
+++ b/web/frontend/src/components/DownloadButton.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { defineProps } from "vue";
+
+const props = defineProps<{
+  text: string;
+  size: number;
+  disabled: boolean;
+}>();
+const convertTextTiImage = () => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d")!;
+
+  ctx.font = props.size.toString + "px serif";
+  canvas.width = ctx.measureText(props.text).width;
+  canvas.height = ctx.measureText(props.text).width * props.text.length;
+  ctx.fillText(props.text, 0, props.size);
+
+  const imageDataURL = canvas.toDataURL("image/png");
+  const link = document.createElement("a");
+  link.download = "image.png";
+  link.href = imageDataURL;
+  link.click();
+};
+</script>
+
+<template>
+  <v-btn :disabled="disabled" @click="convertTextTiImage">画像に変換</v-btn>
+</template>
+
+<style scoped></style>

--- a/web/frontend/src/pages/TopPage.vue
+++ b/web/frontend/src/pages/TopPage.vue
@@ -6,6 +6,7 @@ import {
 } from "../features/starrykids/usecase/TextToMoonsUsecase";
 import { TextToMoonsRequest } from "../features/starrykids/model/TextToMoons";
 import TheFooter from "../components/TheFooter.vue";
+import DownloadButton from "../components/DownloadButton.vue";
 
 // リクエストするときのサイズ
 const size = ref<number>(15);
@@ -132,7 +133,15 @@ onErrorCaptured((err: Error) => {
           </v-sheet>
         </v-col>
         <v-col cols="12" md="6" lg="6">
-          <v-btn @click="copy">コピー</v-btn>
+          <v-row class="mt-2 ml-1 mb-2">
+            <v-btn @click="copy">コピー</v-btn>
+            <DownloadButton
+              class="ml-2"
+              :text="moonText"
+              :size="textareaFontSize"
+              :disabled="moonText.length === 0"
+            />
+          </v-row>
           <v-row class="mt-2 ml-1">
             <v-chip variant="outlined" color="primary" label>
               テキストサイズ


### PR DESCRIPTION
## 🥅 このプルリクのゴール / Resolved Issues
- 画像保存機能を作成する
  - 実際に画像を保存できる 

## 👏 解決する issue / Resolved Issues
<!-- 解決するissueがある場合はissue番号と内容を書いて下さい -->
- close https://github.com/Tatsumi0000/starry-kids/issues/205

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 渡された文字列を画像に変換する`DownloadButton.vue`を作成
  - 仮想DOM上にcanvas要素を作成し渡された文字列を元にサイズを決めて作成。渡されたテキストをcanvasに描画する。
  - 仮想DOM上にa要素を作成しcanvas要素に描画したテキストをダウンロードする。
  - textAreaに描画が空っぽだと`DownloadButton.vue`をクリックできないようにする。
- ついでに整形した。

## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

<img width="1196" alt="Screenshot 2024-04-06 at 1 06 06" src="https://github.com/Tatsumi0000/starry-kids/assets/19218690/f0f7ae4b-7018-4542-a74a-b3067ed37434">

## ❗️ 気になる点 / Concern points
- なし
