### PR TITLE
canvas内では改行コードを認識してくれないのでそれを考慮した設計に修正

### DIFF
--- a/web/frontend/src/components/DownloadButton.vue
+++ b/web/frontend/src/components/DownloadButton.vue
@@ -9,11 +9,22 @@ const props = defineProps<{
 const convertTextTiImage = () => {
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d")!;
+  // 改行コードで分割
+  const lines = props.text.split("\n");
 
   ctx.font = props.size.toString + "px serif";
-  canvas.width = ctx.measureText(props.text).width;
-  canvas.height = ctx.measureText(props.text).width * props.text.length;
-  ctx.fillText(props.text, 0, props.size);
+  // 1行あたりの高さを取得
+  const lineHeight =
+    ctx.measureText(props.text).actualBoundingBoxAscent +
+    ctx.measureText(props.text).actualBoundingBoxDescent;
+
+  canvas.width = ctx.measureText(props.text.split("\n")[0]).width;
+  canvas.height = lineHeight * lines.length;
+
+  // canvas要素では改行を認識してくれないので「/n」で分割して1行ずつ描画
+  lines.map((line, index) => {
+    ctx.fillText(line, 0, 0 + (index + 1) * lineHeight);
+  });
 
   const imageDataURL = canvas.toDataURL("image/png");
   const link = document.createElement("a");


### PR DESCRIPTION
## 🥅 このプルリクのゴール / Resolved Issues
- 画像変換機能がうまく動いてないので修正します。
- 画像をダウンロードできることを確認する。

## 👏 解決する issue / Resolved Issues
<!-- 解決するissueがある場合はissue番号と内容を書いて下さい -->
- close #207 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- canvas内では改行コードを認識してくれないので改行コードをもとに分割して一行ずつ挿入する。
- canvasのサイズが大きすぎてエラーになってる？っぽかった（そもそもサイズ指定が間違ってた）ので、`1行あたりの高さ x 改行コードの数`で高さを求めるようにした。


## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

<details>
    <summary>実際に出力した画像（長いので折りたたみ）</summary>

 <img src="https://github.com/Tatsumi0000/starry-kids/assets/19218690/a84ce633-05e5-4814-b39b-49206e51e565" width="350" alt="">

</details>

## ❗️ 気になる点 / Concern points
- 特になし
