### PR TITLE
Docker Desktopのクラスタで動くk8sマニフェストを作成

### DIFF
--- a/web/infra/base/deployment.yaml
+++ b/web/infra/base/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starry-kids
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starry-kids
+  template:
+    metadata:
+      labels:
+        app: starry-kids
+    spec:
+      containers:
+        - name: frontend
+          image: frontend-image
+          ports:
+            - containerPort: 5173
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "250m"
+          command: 
+            - "npm"
+            - "run"
+            - "dev"

--- a/web/infra/base/kustomization.yaml
+++ b/web/infra/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: "starry-kids"
+
+resources:
+  - deployment.yaml
+
+images:
+  - name: frontend-image
+    newName: ghcr.io/tatsumi0000/starry-kids/frontend
+    newTag: latest

--- a/web/infra/overlays/development/deployment.patch.yaml
+++ b/web/infra/overlays/development/deployment.patch.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starry-kids
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starry-kids
+  template:
+    metadata:
+      labels:
+        app: starry-kids
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/tatsumi0000/starry-kids/backend:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "769Mi"
+          command:
+            - "bin/rails"
+            - "s"
+            - "-b"
+            - "0.0.0.0"
+        - name: db
+          image: mysql:8.1.0
+          ports:
+            - containerPort: 3306
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "769Mi"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: "password"

--- a/web/infra/overlays/development/kustomization.yaml
+++ b/web/infra/overlays/development/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: "starry-kids"
+
+resources:
+  - "../../base"
+
+patches:
+  - path: deployment.patch.yaml


### PR DESCRIPTION
## 🥅 このプルリクのゴール / Resolved Issues
- Docker Desktopで動作するk8sマニフェストを作成
  - kustomizeを使って、↓のような処理にしたいです
    - `development`だとローカルVue→ローカルRailsで通信する
    - `production`だとローカル→本番Railsで通信する
 

## 👏 解決する issue / Resolved Issues
<!-- 解決するissueがある場合はissue番号と内容を書いて下さい -->
- close #226


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 新たに`web/infra`ディレクトリを作りそこにk8sのマニフェストを作りました
  - `base`が基本的な共通処理を書きます（Vueの設定）
  - `development`がローカルVue→ローカルRailsなマニフェスト
  - `production`がローカル→本番Railsなマニフェスト


## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

## ❗️ 気になる点 / Concern points
- XXXX
