### PR TITLE
npm run build時に起こるエラーTS6305を修正

### DIFF
--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -27,7 +27,6 @@
     "src/**/*.d.ts",
     "plugins/**/*.ts",
     "tests/**/*.ts",
-    "vite.config.ts",
     "vitest.config.ts"
   ],
   "references": [

--- a/web/frontend/vitest.config.ts
+++ b/web/frontend/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig, mergeConfig } from "vitest/config";
-import viteConfig from "./vite.config";
+import { defineConfig } from "vitest/config";
+import { fileURLToPath, URL } from "node:url";
+import vue from "@vitejs/plugin-vue";
+import vuetify from "vite-plugin-vuetify";
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
+export default defineConfig({
+    plugins: [vue(), vuetify({ autoImport: true })],
     test: {
       globals: true,
       environment: "jsdom",
@@ -13,5 +14,9 @@ export default mergeConfig(
         },
       },
     },
-  }),
-);
+    resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- vite.config.tsで循環参照が発生していたようなので修正
- それに伴ってvitest.config.tsでVuetifyのロードが上手く行かなくなったので修正


## 📸 スクリーンショット / Screenshots
<!-- UIなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in UI would be easier to review with screenshots! -->

## ❗️ 気になる点 / Concern points
- XXXX
